### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/web-vuln.yml
+++ b/.github/workflows/web-vuln.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 
 jobs:
   scan:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/1](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/1)

To fix this problem, you need to add a `permissions` block to the workflow. Since the workflow only checks out the code and uploads an artifact, it minimally needs `contents: read` to fetch repository contents during checkout. It does not interact with issues, pull requests, or require write access to contents. The `permissions` key can be added at the job level (just before `runs-on`) to apply only to the `scan` job, or globally at the workflow level (immediately after the `name` and `on` keys) to apply to all jobs. Either approach is acceptable; here, we’ll add it at the job level for clarity. Add the following block above `runs-on: ubuntu-latest`:
```yaml
permissions:
  contents: read
```
No new imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
