### PR TITLE
Potential fix for code scanning alert no. 7: Disabling certificate validation

### DIFF
--- a/lib/scanners/ssl-tls.js
+++ b/lib/scanners/ssl-tls.js
@@ -125,7 +125,6 @@ async function checkCertificate(hostname, port) {
     const options = {
       host: hostname,
       port: port,
-      rejectUnauthorized: false,
       timeout: 10000
     };
     


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/7](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/7)

To address the issue, remove the `rejectUnauthorized: false` setting from the TLS connection options and instead allow TLS to use its default behavior, which validates server certificates. If the intent is to scan the SSL certificate of a server regardless of its validity, consider catching errors resulting from invalid certificates and reporting them, rather than disabling validation. Specifically, in file `lib/scanners/ssl-tls.js`, remove the `rejectUnauthorized: false` line from the `options` object in the `checkCertificate` function (lines 125-130). No additional imports or method changes are necessary—just remove this insecure option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
