### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL scheme check

### DIFF
--- a/lib/scanners/xss.js
+++ b/lib/scanners/xss.js
@@ -76,14 +76,21 @@ async function scan(page, url) {
       const links = dom.window.document.querySelectorAll('a');
       links.forEach(link => {
         const href = link.getAttribute('href');
-        if (href && href.toLowerCase().startsWith('javascript:')) {
-          results.push({
-            type: 'javascript_uri',
-            description: 'Link uses javascript: URI which can be a vector for XSS attacks.',
-            recommendation: 'Avoid using javascript: URIs. Use event handlers or buttons instead.',
-            severity: 'medium',
-            evidence: link.outerHTML
-          });
+        if (href) {
+          const scheme = href.trim().toLowerCase();
+          if (
+            scheme.startsWith('javascript:') ||
+            scheme.startsWith('data:') ||
+            scheme.startsWith('vbscript:')
+          ) {
+            results.push({
+              type: 'javascript_uri',
+              description: 'Link uses a URI scheme (javascript:, data:, or vbscript:) which can be a vector for XSS attacks.',
+              recommendation: 'Avoid using URIs with javascript:, data:, or vbscript: schemes. Use event handlers or buttons instead.',
+              severity: 'medium',
+              evidence: link.outerHTML
+            });
+          }
         }
       });
       


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/9](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/9)

The code should be updated in lib/scanners/xss.js to ensure that links whose `href` attributes start with either `javascript:`, `data:`, or `vbscript:` (case-insensitive, and possibly with whitespace) are flagged as XSS risks. Specifically, line 79 inside the `links.forEach` block should be replaced with a check for all three schemes. The logic should remain as close as possible to the original to avoid breaking any existing functionality; we simply broaden the set of schemes we consider risky. No external library is needed, but it is best to trim possible whitespace and normalize the case when performing the check, as in the prior lines.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
