### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,6 @@
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/2](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/2)

To fix the problem, add a `permissions` block to your workflow file. The best practice is to set the minimal required permissions at the workflow root level, which applies as a default to all jobs unless overridden. For this npm publish workflow, the jobs do not require write access to any GitHub resources: the `publish-npm` job uses npm authentication via a secret, and no step is interacting with repository contents, issues, or pull requests. Therefore, we should set `permissions: contents: read` at the workflow level to restrict the GITHUB_TOKEN. 

Edit the `.github/workflows/npm-publish.yml` file and insert:

```yaml
permissions:
  contents: read
```

immediately after the `name:` field and before the `on:` field (line 2-3). No imports or extra dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
