### PR TITLE
Potential fix for code scanning alert no. 4: Bad HTML filtering regexp

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -2,6 +2,7 @@ const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch
 const { JSDOM } = require('jsdom');
 const { URL } = require('url');
 const debug = require('debug')('web-vuln-scanner:crawler');
+const sanitizeHtml = require('sanitize-html');
 
 // Handle p-limit as ES module
 let pLimit;
@@ -142,12 +143,13 @@ class Crawler {
 
   // Strip resource-loading elements to prevent JSDOM errors
   stripResourceElements(html) {
-    return html
-      .replace(/<link[^>]*>/gi, '<!-- link removed -->')
-      .replace(/<script[^>]*src[^>]*>.*?<\/script>/gis, '<!-- script removed -->')
-      .replace(/<img[^>]*>/gi, '<img>')
-      .replace(/<iframe[^>]*>.*?<\/iframe>/gis, '<!-- iframe removed -->')
-      .replace(/<(object|embed)[^>]*>.*?<\/\1>/gis, '<!-- $1 removed -->');
+    return sanitizeHtml(html, {
+      allowedTags: sanitizeHtml.defaults.allowedTags.filter(tag =>
+        !['link', 'script', 'img', 'iframe', 'object', 'embed'].includes(tag)
+      ),
+      allowedAttributes: false,
+      selfClosing: [],
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "puppeteer": "^24.6.1",
         "spinner": "^0.3.4",
         "wappalyzer": "^7.0.3",
-        "web-vuln-scanner": "^1.0.7"
+        "web-vuln-scanner": "^1.0.7",
+        "sanitize-html": "^2.17.0"
     },
     "engines": {
         "node": ">=12.0.0"


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/4](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/4)

The best way to fix this problem is to avoid using a custom regular expression entirely for stripping HTML tags and, instead, use a well-tested library that safely removes or sanitizes unwanted elements. For Node.js, the `sanitize-html` package is a popular option that robustly handles these cases, including malformed or non-standard HTML tags.

In file `lib/crawler.js`, within the `stripResourceElements(html)` method (lines 144–151), replace the chain of `replace` calls that use custom regular expressions with a call to `sanitize-html`, specifying a set of allowed tags (excluding resource-loading elements such as `<link>`, `<script>`, `<img>`, `<iframe>`, `<object>`, `<embed>`, etc.). This approach ensures all unwanted elements are removed regardless of tag casing or malformed tags.

Edit the file to:
- Add the (standard Node.js) `sanitize-html` import at the top.
- Rewrite the `stripResourceElements` method to use `sanitize-html`, configuring it to remove resource-loading tags.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
