### PR TITLE
Potential fix for code scanning alert no. 5: Bad HTML filtering regexp

### DIFF
--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -185,7 +185,7 @@ class Scanner {
       // Remove all link elements (CSS, etc.)
       .replace(/<link[^>]*>/gi, '<!-- link removed -->')
       // Remove script elements with src attributes
-      .replace(/<script[^>]*src[^>]*>.*?<\/script>/gis, '<!-- script removed -->')
+      .replace(/<script[^>]*src[^>]*>.*?<\/script\b[^>]*>/gis, '<!-- script removed -->')
       // Remove img elements with external src
       .replace(/<img[^>]*src=["'][^"']*["'][^>]*>/gi, '<img>')
       // Remove iframe elements


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/5](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/5)

The best practice for filtering or sanitizing HTML is to use a well-tested library rather than custom regex. However, since the code is already using regex, a short-term mitigation is to update the regular expression to match closing `</script>` tags that may have extra attributes or whitespace, i.e., allowing `</script>` with optional space and/or attributes after `script`, before `>`. This change should be made on line 188 in `lib/scanner.js`. Optionally, for best security and maintainability, a full switch to a trusted HTML sanitizer (e.g., `sanitize-html` or `dompurify`) is recommended, but for now, adjusting the regex minimizes risk without changing core functionality.

No imports are needed for this regex fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
