### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL scheme check

### DIFF
--- a/lib/crawler-puppeteer.js
+++ b/lib/crawler-puppeteer.js
@@ -670,12 +670,15 @@ class PuppeteerCrawler {
 
   processFoundUrl(url, baseUrl) {
     try {
+      // Normalize: trim and to lower case for scheme checks
+      let normalized = typeof url === 'string' ? url.trim().toLowerCase() : '';
       if (!url || 
-          url.startsWith('#') ||
-          url.startsWith('mailto:') ||
-          url.startsWith('tel:') ||
-          url.startsWith('javascript:') ||
-          url.startsWith('data:')) {
+          normalized.startsWith('#') ||
+          normalized.startsWith('mailto:') ||
+          normalized.startsWith('tel:') ||
+          normalized.startsWith('javascript:') ||
+          normalized.startsWith('data:') ||
+          normalized.startsWith('vbscript:')) {
         return null;
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/8](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/8)

To effectively patch the vulnerability, update the URL scheme checks in the `processFoundUrl` method to reject URLs starting with `vbscript:`, in addition to the already-blocked `javascript:` and `data:` schemes. This should be done in a case-insensitive manner, and ideally after trimming leading whitespace, as executable schemes may appear in various cases and forms.

The best way to do this without breaking existing functionality is:
- Normalize the URL string: trim leading whitespace and convert to lower case before checking.
- When checking the scheme, include `'vbscript:'` alongside `'javascript:'` and `'data:'`.

Changes are only needed in the `processFoundUrl` function in `lib/crawler-puppeteer.js`, lines 671–680. No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
