### PR TITLE
Potential fix for code scanning alert no. 13: Prototype-polluting function

### DIFF
--- a/lib/config/config-manager.js
+++ b/lib/config/config-manager.js
@@ -383,8 +383,14 @@ class ConfigManager {
 
   set(path, value) {
     const keys = path.split('.');
+    // Block prototype pollution by skipping dangerous keys
+    for (const k of keys) {
+      if (k === '__proto__' || k === 'constructor') {
+        // Optionally, throw an error or simply ignore
+        return;
+      }
+    }
     let current = this.config;
-
     for (let i = 0; i < keys.length - 1; i++) {
       const key = keys[i];
       if (!current[key] || typeof current[key] !== 'object') {
@@ -392,7 +398,6 @@ class ConfigManager {
       }
       current = current[key];
     }
-
     current[keys[keys.length - 1]] = value;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/13](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/13)

To fix the prototype pollution vulnerability, we should block property names that could affect the JavaScript prototype chain. Specifically, within the loop in the `set` method, we should skip (or throw an error for) any property name that is `"__proto__"` or `"constructor"`. Similarly, the final assigned property name (`keys[keys.length - 1]`) should also not be one of these. 

The fix consists of:
- Before entering the assignment loop, use a check to skip or prevent setting any key along the path that is `"__proto__"` or `"constructor"` (or `"prototype"`, though the standard is to only block the first two).
- If any such property is in the property chain, return early, or throw an error—whichever suits the intended security posture for the configuration manager.
- No external imports are needed. The fix requires local addition of logic in the `set` method itself.

We will update the method in lib/config/config-manager.js, lines 384–397.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
