### PR TITLE
Potential fix for code scanning alert no. 14: Sensitive data read from GET request

### DIFF
--- a/lib/auth/auth-middleware.js
+++ b/lib/auth/auth-middleware.js
@@ -112,7 +112,12 @@ class AuthMiddleware {
     let apiKey = req.headers['x-api-key'] || req.headers['api-key'];
     
     // Check query parameter (less secure, for convenience)
-    if (!apiKey && this.config.get('auth.allowApiKeyInQuery', false)) {
+    // Prevent reading API keys from query parameters for GET requests
+    if (
+      !apiKey &&
+      this.config.get('auth.allowApiKeyInQuery', false) &&
+      req.method !== 'GET'
+    ) {
       apiKey = req.query.api_key || req.query.apikey;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/14](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/14)

To fix this issue, remove or severely restrict the code reading API keys from the query string in GET requests. The recommended general solution is to allow API keys only from request headers, and disallow passing API keys via query parameters by default, especially in production environments. 

Specifically, in file `lib/auth/auth-middleware.js`, in the `extractAPIKey(req)` method, remove or refactor the block reading from `req.query.api_key` and `req.query.apikey` (lines 115-117). Ideally, you should either remove this block entirely or restrict it so it's only accessible for non-GET requests or when running in explicitly whitelisted, safe environments.

Here, the best fix is to completely prohibit reading API keys from query params for GET requests. If you want to keep configuration flexibility, you might want to allow it *only* for POST requests (where data is not logged in the URL).

You will need to:
- Edit the region in `extractAPIKey(req)` (lines 115-117) to prohibit reading API keys from query parameters for GET requests.
- Optionally update any log messages or error handling if needed.

No additional dependencies are needed for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
