### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/10](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/10)

To fix the problem, explicitly declare the `permissions` key near the top (at the root) of the workflow file `.github/workflows/ci.yml`, before the `jobs` block. This will apply the restricted permissions to all jobs unless overridden. The minimal safe setting for most CI/CD jobs that do not modify repository contents or interact with issues/PRs is:

```yaml
permissions:
  contents: read
```

This ensures the GITHUB_TOKEN only has read-only access to the repository contents, adhering to the principle of least privilege. Insert this block after the `name: CI` line and before the `on:` trigger.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
