### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/12](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/12)

To resolve this issue, add a `permissions:` block to the workflow, specifying the minimal required permissions. Since neither the `test` nor `security-scan` job requires write access to the repository (e.g. no code changes, no issue/PR updates), set `contents: read` at the workflow root. This will restrict the GITHUB_TOKEN to only read repository contents, unless a specific job needs additional permissions in the future. The change should be made at the top level of `.github/workflows/ci.yml`, directly below the `name:` field and before job definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
