### PR TITLE
Potential fix for code scanning alert no. 18: Missing rate limiting

### DIFF
--- a/lib/auth/auth-router.js
+++ b/lib/auth/auth-router.js
@@ -6,6 +6,7 @@
 const express = require('express');
 const helmet = require('helmet');
 const cors = require('cors');
+const rateLimit = require('express-rate-limit');
 const { AuthMiddleware } = require('./auth-middleware');
 const { UserService } = require('./user-service');
 const { APIKeyManager } = require('./apikey-manager');
@@ -403,6 +404,18 @@ class AuthRouter {
       this.authMiddleware.requireAdmin()
     ];
 
+    // Admin rate limiter - max 30 requests per 15 minutes per user/IP
+    const adminLimiter = rateLimit({
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      max: 30, // limit each IP/user to 30 requests per windowMs
+      standardHeaders: true, 
+      legacyHeaders: false,
+      message: {
+        error: 'Too many requests, please try again later.',
+        code: 'TOO_MANY_REQUESTS'
+      }
+    });
+
     // List all users
     this.router.get('/admin/users', adminAuth, (req, res) => {
       try {
@@ -424,7 +437,7 @@ class AuthRouter {
     });
 
     // Get user statistics
-    this.router.get('/admin/stats', adminAuth, (req, res) => {
+    this.router.get('/admin/stats', adminAuth, adminLimiter, (req, res) => {
       try {
         const stats = this.userService.getUserStats();
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
         "source-map-js": "^1.0.2",
         "through": "^2.3.8",
         "tough-cookie": "^6.0.0",
-        "wrap-ansi": "^9.0.2"
+        "wrap-ansi": "^9.0.2",
+        "express-rate-limit": "^8.1.0"
     },
     "devDependencies": {
         "@types/jest": "^29.5.5",


### PR DESCRIPTION
Potential fix for [https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/18](https://github.com/pratikacharya1234/Web-Vulnerability-Scanner/security/code-scanning/18)

To fix this issue, we should add rate limiting to the `/admin/stats` route (and ideally other sensitive admin routes). This can be done by importing a popular and well-maintained rate limiting middleware such as `express-rate-limit`, defining a suitable limiter configuration (for example, 30 requests per 15 minutes for admin endpoints), and applying the middleware to the route handler. Since the code is in a class method and the router is instance-bound (`this.router.get(...)`), we will instantiate the limiter inside the `AuthRouter` class.

Steps:
- Add the required `express-rate-limit` import at the top of the file.
- Inside the `setupAdminRoutes` method, define a rate limiter instance.
- Apply the rate limiter as middleware to the `/admin/stats` route (and potentially other admin routes if desired, but for this fix, focus on `/admin/stats`).
- Ensure the fix is non-intrusive (does not affect existing functionality) and the limiter configuration is reasonable.

All changes are to be made in `lib/auth/auth-router.js`, within the regions shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
